### PR TITLE
Allow soloistrc to provide node attributes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,6 +101,23 @@ Local Overrides (experimental)
 ==============================
 Soloist is an easy way to share configuration across workstations.  If you want to have configuration in chef that you don't want to share with the rest of the project, you can create a soloistrc_local file in addition to the soloistrc file.  This file will be processed after the soloistrc, and everything in it will be added to the run list.  Be careful that you are clear what goes where - if it's a dependency of the project, it should be checked into the soloistrc file in the project.
 
+Setting Node Attributes
+=======================
+You can set node attributes in your soloistrc file that will be included in the JSON attributes file passed to chef-solo.
+
+    cookbook_paths:
+    - ./chef/cookbooks/
+    recipes:
+    - pivotal_workstation::github_ssh_keys
+    - pivotal_workstation::rvm
+    node:
+      github_username: john.smith
+      github_password: pas$w0rd
+      rvm:
+        rubies:
+          ruby-1.8.7-p299: {}
+          jruby-1.6.6: {}
+
 License
 =======
 Soloist is MIT Licensed.  See MIT-LICENSE for details.

--- a/lib/soloist/chef_config_generator.rb
+++ b/lib/soloist/chef_config_generator.rb
@@ -9,6 +9,7 @@ module Soloist
       @cookbook_paths = []
       @cookbook_gems = []
       @preserved_environment_variables = %w{PATH BUNDLE_PATH GEM_HOME GEM_PATH RAILS_ENV RACK_ENV}
+      @node_attributes = config['node'] || {}
       merge_config(config, relative_path_to_soloistrc)
     end
     
@@ -65,7 +66,7 @@ module Soloist
     def json_hash
       {
         "recipes" => @recipes
-      }
+      }.merge(@node_attributes)
     end
   
     def json_file

--- a/spec/chef_config_generator_spec.rb
+++ b/spec/chef_config_generator_spec.rb
@@ -106,6 +106,12 @@ env_variable_switches:
       @generator = Soloist::ChefConfigGenerator.new(YAML.load(@config), "")
       @generator.json_hash.should == { "recipes" => ["pivotal_workstation::ack"]}
     end
+    
+    it "should set node attributes" do
+      @config = "node:\n  github_username: avh4"
+      @generator = Soloist::ChefConfigGenerator.new(YAML.load(@config), "")
+      @generator.json_hash.should == { "recipes" => [], "github_username" => "avh4" }
+    end
   end
   
   describe "environment variable merging" do


### PR DESCRIPTION
Is there a better way to specify node attributes when using soloist?

If something like this is worth including, is "node" the best key to use?  Maybe "attributes" instead?
