### PR TITLE
Evaluates the soloistrc YAML file as erb

### DIFF
--- a/lib/soloist/royal_crown.rb
+++ b/lib/soloist/royal_crown.rb
@@ -41,7 +41,7 @@ module Soloist
 
     def self.read_config(yaml_file)
       content = File.read(yaml_file)
-      YAML.load(content).tap do |hash|
+      YAML.load(ERB.new(content).result).tap do |hash|
         nilable_properties.each do |key|
           hash.delete(key) if hash[key].nil?
         end if hash

--- a/spec/lib/soloist/royal_crown_spec.rb
+++ b/spec/lib/soloist/royal_crown_spec.rb
@@ -31,6 +31,28 @@ describe Soloist::RoyalCrown do
     it "defaults nil fields to an empty primitive" do
       royal_crown.node_attributes.should == {}
     end
+
+    context "when the rc file has ERB tags" do
+      let(:tempfile) do
+        Tempfile.new("soloist-royalcrown").tap do |file|
+          file.write(<<-YAML
+          recipes:
+            - broken_vim
+          node_attributes:
+            evaluated: <%= "From ERB" %>
+          YAML
+          )
+          file.close
+        end
+      end
+
+      it "evaluates the ERB and parses the resulting YAML" do
+        royal_crown.node_attributes.should == {
+          "evaluated" => "From ERB"
+        }
+        royal_crown.recipes.should =~ ["broken_vim"]
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
We are creating a cookbook recipe that needs a node attribute for a password.  We need to prompt the user for this password at the time the soloistrc file is parsed, so that the password is not saved anywhere.  We changed soloist to eval the soloistrc yaml file before loading it.
