### PR TITLE
Lockdown Chef version; workaround ohai regression

### DIFF
--- a/soloist.gemspec
+++ b/soloist.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency "chef"
+  s.add_dependency "chef", "~> 11.16.4"
   s.add_dependency "librarian-chef"
   s.add_dependency "thor"
   s.add_dependency "hashie", "~> 2.0"


### PR DESCRIPTION
ohai recently started reporting root as the current user instead of the SUDO_USER, I think this was due to this commit: https://github.com/opscode/ohai/commit/fec9467a0c93b203e97447207352745536c2b471

This change breaks a bunch of recipes in sprout so we need a temporary solution until we figure out the right thing to do in response to the ohai change.
