### PR TITLE
Always run Ohai Passwd plugin to support Chef >= 14.0.13

### DIFF
--- a/lib/soloist/config.rb
+++ b/lib/soloist/config.rb
@@ -28,6 +28,7 @@ module Soloist
         file_cache_path "#{chef_cache_path}"
         cookbook_path #{cookbook_paths.inspect}
         json_attribs "#{node_json_path}"
+        ohai.optional_plugins = [ :Passwd ] if ohai.respond_to?(:optional_plugins)
       SOLO_RB
     end
 

--- a/spec/lib/soloist/config_spec.rb
+++ b/spec/lib/soloist/config_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Soloist::Config do
 
     it { should include 'file_cache_path "/var/chef/cache"' }
     it { should include %(json_attribs "#{config.node_json_path}") }
+    it { should include 'ohai.optional_plugins = [ :Passwd ] if ohai.respond_to?(:optional_plugins)' }
   end
 
   describe "#cookbook_paths" do


### PR DESCRIPTION
Adds line to `solo.rb` config file:

     ohai.optional_plugins = [ :Passwd ] if ohai.respond_to?(:optional_plugins)

Many `sprout*` cookbooks use the [`sprout-base::home` attribute][1], but newer versions of Chef Infra Client [do not populate this Ohai attribute by default anymore][3]!

Fix the issue by always running the Ohai `:Passwd` plugin to support Chef `>= 14.0.13`

#### Changes:

 - Force run of Ohai Passwd plugin to populate `node['etc']['passwd']` for Chef/Ohai >= 14.0.13
 - Guard with `ohai.respond_to?(optional_plugins)` to support older Chef + Ohai versions

Build tested when [merged against Pull Request #40 here][4].  (Due to old `.travis.yml` RVM ruby versions that no longer worked)

#### References:

 - [https://github.com/chef/ohai/blob/master/RELEASE_NOTES.md#optional-ohai-plugins][2]
 - [https://stackoverflow.com/a/57953198/64549][3]

[1]: https://github.com/pivotal-sprout/sprout-base/blob/master/attributes/home.rb#L5
[2]: https://github.com/chef/ohai/blob/master/RELEASE_NOTES.md#optional-ohai-plugins
[3]: https://stackoverflow.com/a/57953198/64549
[4]: https://www.travis-ci.com/github/trinitronx/soloist/builds/222080227